### PR TITLE
Add missing permission for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The release workflow token has insufficient permissions to allow it to upload releases