### PR TITLE
Update go to 1.20.5 in workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.3
+        go-version: 1.20.5
     
     - name: Install depedencies
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.3
+        go-version: 1.20.5
     
     - name: Install depedencies
       run: |


### PR DESCRIPTION
Fixes an error in release workflow which throws security vuln on not using 1.20.5